### PR TITLE
Add validation schemas

### DIFF
--- a/frontend/src/utils/validationSchemas.js
+++ b/frontend/src/utils/validationSchemas.js
@@ -1,0 +1,34 @@
+import { string } from 'yup';
+
+export const login = () =>
+  string()
+    .trim()
+    .required('signUp.validation.requiredField')
+    .min(3, 'signUp.validation.usernameLength')
+    .max(16, 'signUp.validation.usernameLength')
+    .matches(/^[\w\S]*$/, 'signUp.validation.correctUsername');
+
+export const email = () =>
+  string()
+    .trim()
+    .required('signUp.validation.requiredField')
+    .email('signUp.validation.correctEmail');
+
+export const password = () =>
+  string()
+    .required('signUp.validation.requiredField')
+    .min(8, 'signUp.validation.passwordLength')
+    .max(30, 'signUp.validation.passwordLength');
+
+export const confirmPassword = () =>
+  string().test(
+    'confirmPassword',
+    'signUp.validation.confirmPassword',
+    (value, context) => value === context.parent.password,
+  );
+
+export const replName = () =>
+  string()
+    .required('modals.validation.required')
+    .max(20, 'modals.validation.snippetNameMaxLength')
+    .matches(/^[a-zA-Z0-9_-]*$/, 'modals.validation.singleWord');


### PR DESCRIPTION
Вынес схемы валидации в отдельный файл. Убрал `trim()` из пароля. Метод удаляет пробельные символы на концах строки. Сейчас у поля `password` где-то в формах он есть, а где-то нет. Надо подумать, нужен ли он.

В любом случае Formik не использует трансформации (типа trim) при отправке формы, он использует yup только для валидации. То есть на сервер уходят все равно строки с пробелами. Поэтому трансформации нужно применять методом `cast`. Типа такого:

```
const preparedValues = validation.cast(values);
```

Где `validation` – это собранная схема валидации. И уже `preparedValues` отправлять на сервер